### PR TITLE
fix: replace break-all with break-words for StreamableText

### DIFF
--- a/src/components/main/Image.tsx
+++ b/src/components/main/Image.tsx
@@ -14,7 +14,7 @@ export default (props: Props) => {
   const messageOutput = () => props.messages().length > 1 ? props.messages()[1] : null
   return (
     <div class="flex flex-col h-full">
-      <div class="min-h-16 max-h-40 fi px-6 py-4 border-b border-base break-all overflow-y-scroll">
+      <div class="min-h-16 max-h-40 fi px-6 py-4 border-b border-base break-words overflow-y-scroll">
         <StreamableText
           class="w-full"
           text={messageInput()?.content || ''}

--- a/src/components/main/MessageItem.tsx
+++ b/src/components/main/MessageItem.tsx
@@ -28,7 +28,7 @@ export default (props: Props) => {
 
   return (
     <div
-      class="p-6 break-all group relative"
+      class="p-6 break-words group relative"
       classList={{
         'op-70 bg-darker': props.message.role === 'user',
       }}

--- a/src/components/main/Single.tsx
+++ b/src/components/main/Single.tsx
@@ -21,13 +21,13 @@ export default ({ conversationId, messages }: Props) => {
 
   return (
     <div class="flex flex-col h-full">
-      <div class="flex-[1] border-b border-base p-6 break-all overflow-y-scroll">
+      <div class="flex-[1] border-b border-base p-6 break-words overflow-y-scroll">
         <StreamableText
           class="mx-auto"
           text={messageInput()?.content || ''}
         />
       </div>
-      <div class="scroll-list flex-[2] p-6 break-all overflow-y-scroll" ref={scrollRef!}>
+      <div class="scroll-list flex-[2] p-6 break-words overflow-y-scroll" ref={scrollRef!}>
         <StreamableText
           class="mx-auto"
           text={messageOutput()?.content || ''}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The text in the StreamableText component is currently using the "break-all" class, which results in words being split between lines and can create a poor user experience. To address this issue, I have replaced "break-all" with the "break-words" class.

### Linked Issues
[Issue](https://github.com/anse-app/anse/issues/7)

### Additional context
Not Applicable
<!-- e.g. is there anything you'd like reviewers to focus on? -->