### PR TITLE
fix(ui): manually implement close-on-outside-click feature for modals

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -41,7 +41,7 @@ export default (props: Props) => {
       <Show when={api().isOpen}>
         <div class="fixed inset-0 z-20 fcc">
           <Portal>
-            <div {...api().backdropProps} class="fixed inset-0 bg-base opacity-60" />
+            <div {...api().backdropProps} class="fixed inset-0 bg-base opacity-60 pointer-events-auto" onclick={() => api().close()} />
           </Portal>
           <div {...api().containerProps}>
             <div {...api().contentProps} class={`bg-base-100 transition-transform ease-out max-w-screen max-h-screen overflow-auto border-base shadow-lg ${containerBaseClass}`}>


### PR DESCRIPTION
🙏 Sorry for not created an Issue before this PR! But I've read what you did in 42c373a, 5691818, and ae35e15 carefully and know what I am doing.

### Description

setting `closeOnOutsideClick` to `true` causes two bug:

1. When there are multiple modal nested, they always close together
2. On mobile services it is even worse

But it seems there do exist a simple and naive way to implement the expected *close-on-outside-click* feature without any problem above.

### Linked Issues

42c373a, 5691818, and ae35e15

### Additional context

