### PR TITLE
fix: remove quotation marks from the generated titles

### DIFF
--- a/src/logics/conversation.ts
+++ b/src/logics/conversation.ts
@@ -90,7 +90,7 @@ export const handlePrompt = async(conversation: Conversation, prompt?: string, s
     const rapidPayload = generateRapidProviderPayload(promptHelper.summarizeText(inputText), provider.id)
     const generatedTitle = await getProviderResponse(provider.id, rapidPayload).catch(() => {}) as string || inputText
     updateConversationById(conversation.id, {
-      name: generatedTitle,
+      name: generatedTitle.replace(/^['"\s]+|['"\s]+$/g, ''),
     })
   }
 }


### PR DESCRIPTION
### Description

Titles generated by `summarizeText()` frequently include quotation marks. Considering prompts' cost,  I think regex is better for simple formatting in this situation.

### Linked Discussions

#18

### Additional context

This solution may lack encapsulation.