### PR TITLE
fix: type field adapted for computers (#6)

### DIFF
--- a/src/components/Send.tsx
+++ b/src/components/Send.tsx
@@ -72,7 +72,7 @@ export default () => {
         onKeyDown={(e) => {
           e.key === 'Enter' && !e.isComposing && !e.shiftKey && handleSend()
         }}
-        class="absolute inset-0 py-4 px-[calc(max(1.5rem,(100%-48rem)/2))] scroll-pa-4 input-base"
+        class="h-full w-full absolute inset-0 py-4 px-[calc(max(1.5rem,(100%-48rem)/2))] scroll-pa-4 input-base"
       />
       <div
         onClick={handleSend}


### PR DESCRIPTION
### Description

Fixes issues with textfield showing too small on desktop computers.

### Linked Issues

#6

### Additional context

I have been using this fix locally on my computer for some time now. Thought I'd share it. Not sure if the placement of the style or the implementation could be improved. It just works pretty well.

The only problem I see is that text can go behind the send button.