### PR TITLE
feat: synchronize conversation name to `document.title`

### DIFF
--- a/src/components/header/ConversationHeaderInfo.tsx
+++ b/src/components/header/ConversationHeaderInfo.tsx
@@ -1,4 +1,4 @@
-import { Show } from 'solid-js'
+import { Show, createEffect } from 'solid-js'
 import { useStore } from '@nanostores/solid'
 import { conversationMap, currentConversationId } from '@/stores/conversation'
 import { useI18n } from '@/hooks'
@@ -10,6 +10,8 @@ export default () => {
   const currentConversation = () => {
     return $conversationMap()[$currentConversationId()]
   }
+
+  createEffect(() => { document.title = currentConversation() ? `Anse • ${(currentConversation().name || t('conversations.untitled'))}` : 'Anse' })
 
   return (
     <div class="fi gap-1 max-w-40vw px-2 overflow-hidden text-sm">


### PR DESCRIPTION
### Description

Display the conversation name in `document.title`.

### Linked Issues

#25

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->