### PR TITLE
feat: set the length of the historical message

### DIFF
--- a/src/providers/openai/handler.ts
+++ b/src/providers/openai/handler.ts
@@ -50,12 +50,10 @@ const handleChatCompletion = async(payload: HandlerPayload, signal?: AbortSignal
     if (m === undefined)
       break
 
-    // Subtract the length of the message from the available tokens
-    maxTokens -= m.content.length
-    if (maxTokens < 0)
+    if (maxTokens - m.content.length < 0)
       break
 
-    // Add the message to the beginning of the messages array
+    maxTokens -= m.content.length
     messages.unshift(m)
   }
 

--- a/src/providers/openai/handler.ts
+++ b/src/providers/openai/handler.ts
@@ -1,5 +1,6 @@
 import { fetchChatCompletion, fetchImageGeneration } from './api'
 import { parseStream } from './parser'
+import type { Message } from '@/types/message'
 import type { HandlerPayload, Provider } from '@/types/provider'
 
 export const handlePrompt: Provider['handlePrompt'] = async(payload, signal?: AbortSignal) => {
@@ -35,14 +36,37 @@ export const handleRapidPrompt: Provider['handleRapidPrompt'] = async(prompt, gl
 }
 
 const handleChatCompletion = async(payload: HandlerPayload, signal?: AbortSignal) => {
+  // An array to store the chat messages
+  const messages: Message[] = []
+
+  let maxTokens = payload.globalSettings.maxTokens as number
+  let messageHistorySize = payload.globalSettings.messageHistorySize as number
+
+  // Iterate through the message history
+  while (messageHistorySize > 0) {
+    messageHistorySize--
+    // Get the last message from the payload
+    const m = payload.messages.pop()
+    if (m === undefined)
+      break
+
+    // Subtract the length of the message from the available tokens
+    maxTokens -= m.content.length
+    if (maxTokens < 0)
+      break
+
+    // Add the message to the beginning of the messages array
+    messages.unshift(m)
+  }
+
   const response = await fetchChatCompletion({
     apiKey: payload.globalSettings.apiKey as string,
     baseUrl: (payload.globalSettings.baseUrl as string).trim().replace(/\/$/, ''),
     body: {
+      messages,
+      max_tokens: maxTokens,
       model: payload.globalSettings.model as string,
-      messages: payload.messages,
       temperature: payload.globalSettings.temperature as number,
-      max_tokens: payload.globalSettings.maxTokens as number,
       top_p: payload.globalSettings.topP as number,
       stream: payload.globalSettings.stream as boolean ?? true,
     },

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -52,6 +52,16 @@ const providerOpenAI = () => {
         step: 1,
       },
       {
+        key: 'messageHistorySize',
+        name: 'Max History Message Size',
+        description: 'The number of retained historical messages will be truncated if the length of the message exceeds the MaxToken parameter.',
+        type: 'slider',
+        min: 1,
+        max: 24,
+        default: 5,
+        step: 1,
+      },
+      {
         key: 'temperature',
         name: 'Temperature',
         type: 'slider',


### PR DESCRIPTION
### Description
Added a button for setting the length of historical messages, and correctly calculates the length of the current user's historical messages upon submission to avoid triggering the MaxTokens error. 

This enhancement greatly improves usability.
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->