### PR TITLE
feat: add chat type settings to the header.

### DIFF
--- a/src/components/header/ConversationMessageSettingButton.tsx
+++ b/src/components/header/ConversationMessageSettingButton.tsx
@@ -1,0 +1,23 @@
+import { useStore } from '@nanostores/solid'
+import { showConversationEditModal } from '@/stores/ui'
+import { currentConversationId } from '@/stores/conversation'
+
+export default () => {
+  // Retrieve the current conversation ID from the store
+  const $currentConversationId = useStore(currentConversationId)
+
+  return (
+    <>
+      {/* Render the following code if the current conversation ID exists */}
+      {$currentConversationId() && (
+        <div
+          class="fcc p-2 rounded-md text-xl hv-foreground"
+          onClick={() => { showConversationEditModal.set(true) }}
+        >
+          {/* Render the carbon settings adjust icon */}
+          <div i-carbon-settings-adjust />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,6 +4,7 @@ import { useLargeScreen } from '@/hooks'
 import ConversationHeaderInfo from './ConversationHeaderInfo'
 import ConversationMessageClearButton from './ConversationMessageClearButton'
 import ConversationMessageShareButton from './ConversationMessageShareButton'
+import ConversationMessageSettingButton from './ConversationMessageSettingButton'
 
 export default () => {
   onMount(() => {
@@ -25,6 +26,7 @@ export default () => {
         <ConversationHeaderInfo />
       </div>
       <div class="fi gap-1 overflow-hidden">
+        <ConversationMessageSettingButton />
         <ConversationMessageClearButton />
         <ConversationMessageShareButton />
         <div


### PR DESCRIPTION
### Description

Add a settings button above the header to conveniently modify the system info while keeping the chat history intact. (Otherwise, clearing the chat history is required every time the system info needs to be modified.)

### Linked Issues


### Additional context
