### PR TITLE
feat(openai): add model `gpt-3.5-turbo-16k-0613`

### DIFF
--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -38,6 +38,7 @@ const providerOpenAI = () => {
           { value: 'gpt-3.5-turbo-0301', label: 'gpt-3.5-turbo-0301' },
           { value: 'gpt-3.5-turbo-0613', label: 'gpt-3.5-turbo-0613' },
           { value: 'gpt-3.5-turbo-16k', label: 'gpt-3.5-turbo-16k' },
+          { value: 'gpt-3.5-turbo-16k-0613', label: 'gpt-3.5-turbo-16k-0613' },
         ],
         default: 'gpt-3.5-turbo',
       },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
https://github.com/anse-app/anse/issues/80 mentioned that the `gpt-3.5-turbo-16k-0613` model is required. I replied in the issue that now `gpt-3.5-turbo-16k` and `gpt-3.5-turbo-16k-0613` are equivalent, but when the new 16k model is released it will cause problems, so I added `gpt-3.5-turbo-16k-0613`.


### Linked Issues

https://github.com/anse-app/anse/issues/80


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
You can check my [comment](https://github.com/anse-app/anse/issues/80#issuecomment-1625685131) in https://github.com/anse-app/anse/issues/80.

And many thanks to the developers for creating such a great project!