### PR TITLE
feat: Add code copy button

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import disableBlocks from './plugins/disableBlocks'
 
 const envAdapter = () => {
   switch (process.env.OUTPUT) {
-    case 'vercel': return vercel()
+    case 'vercel': return vercel({ analytics: false }) // Set `analytics` to `true` if you want to use Vercel Analytics
     case 'netlify': return netlify()
     default: return node({ mode: 'standalone' })
   }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "solid-emoji-picker": "^0.2.0",
     "solid-js": "1.7.7",
     "solid-transition-group": "^0.2.2",
+    "solidjs-use": "^2.3.0",
     "unified": "^10.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@astrojs/netlify':
     specifier: 2.3.0
@@ -124,6 +128,9 @@ dependencies:
   solid-transition-group:
     specifier: ^0.2.2
     version: 0.2.2(solid-js@1.7.7)
+  solidjs-use:
+    specifier: ^2.3.0
+    version: 2.3.0
   unified:
     specifier: ^10.1.2
     version: 10.1.2
@@ -649,6 +656,7 @@ packages:
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -1818,7 +1826,7 @@ packages:
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.27.5)(eslint@8.44.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.44.0)
       eslint-plugin-html: 6.2.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint@8.44.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0)
       eslint-plugin-jsonc: 2.9.0(eslint@8.44.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.44.0)
       eslint-plugin-markdown: 2.2.1(eslint@8.44.0)
@@ -1911,6 +1919,7 @@ packages:
 
   /@jridgewell/source-map@0.3.4:
     resolution: {integrity: sha512-KE/SxsDqNs3rrWwFHcRh15ZLVFrI0YoZtgAdIyIq9k5hUNmiWRXXThPomIxHuL20sLdgzbDFyvkUMna14bvtrw==}
+    deprecated: the version has a bug with typescript type resolution
     dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
@@ -2192,6 +2201,16 @@ packages:
       solid-js: 1.7.7
     dev: false
 
+  /@solidjs-use/shared@2.3.0:
+    resolution: {integrity: sha512-xuPNzZ9fwigkmYXTO+a8kaT45XQCPt6jVlyiDDYCD9NRZheRJOZWiUcVjYHzjececbWTctcY8NFdsXVyxARHKg==}
+    dependencies:
+      '@solidjs-use/solid-to-vue': 2.3.0
+    dev: false
+
+  /@solidjs-use/solid-to-vue@2.3.0:
+    resolution: {integrity: sha512-I2onRwzdYl2eq20M3hcTkVIeYq4hNoBpHvRJB9yzoyXRDSyp7R2glIbvdBzpsXqnTvX7HJhB2KePfxYXFvyJxw==}
+    dev: false
+
   /@surma/rollup-plugin-off-main-thread@2.2.3:
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
     dependencies:
@@ -2331,6 +2350,10 @@ packages:
 
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+
+  /@types/web-bluetooth@0.0.16:
+    resolution: {integrity: sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==}
+    dev: false
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -4609,7 +4632,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.44.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint@8.44.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0)
       eslint-plugin-n: 15.7.0(eslint@8.44.0)
       eslint-plugin-promise: 6.1.1(eslint@8.44.0)
     dev: true
@@ -4633,7 +4656,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.44.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint@8.44.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.2
@@ -4642,7 +4665,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-node@0.3.7)(eslint@8.44.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4667,6 +4690,7 @@ packages:
       debug: 3.2.7
       eslint: 8.44.0
       eslint-import-resolver-node: 0.3.7
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.27.5)(eslint@8.44.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4716,7 +4740,7 @@ packages:
       htmlparser2: 7.2.0
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.60.1)(eslint@8.44.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4734,7 +4758,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.44.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-node@0.3.7)(eslint@8.44.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.60.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@2.7.1)(eslint@8.44.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -8524,6 +8548,13 @@ packages:
       '@solid-primitives/refs': 1.0.4(solid-js@1.7.7)
       '@solid-primitives/transition-group': 1.0.2(solid-js@1.7.7)
       solid-js: 1.7.7
+    dev: false
+
+  /solidjs-use@2.3.0:
+    resolution: {integrity: sha512-ZyH2jiUSQU+5S5vd8zyvqz9X2ikhMjJhDeh/TjRzjLDJlZ1RuZaMxdM+jGsrJxo3X/xBW9kDpYNONXs6wYrQCQ==}
+    dependencies:
+      '@solidjs-use/shared': 2.3.0
+      '@types/web-bluetooth': 0.0.16
     dev: false
 
   /source-map-js@1.0.2:

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,4 +1,5 @@
-import { Show } from 'solid-js'
+import { Show, createSignal } from 'solid-js'
+import { useClipboard, useEventListener } from 'solidjs-use'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -31,7 +32,54 @@ const parseMarkdown = (raw: string) => {
 }
 
 export default (props: Props) => {
-  const htmlString = () => props.showRawCode ? props.text : parseMarkdown(props.text)
+  const [source] = createSignal('')
+  const { copy, copied } = useClipboard({ source, copiedDuring: 1000 })
+
+  useEventListener('click', (e) => {
+    const el = e.target as HTMLElement
+    let code = null
+
+    if (el.matches('div > div.copy-btn')) {
+      code = decodeURIComponent(el.dataset.code!)
+      copy(code)
+    }
+    if (el.matches('div > div.copy-btn > svg')) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+      code = decodeURIComponent(el.parentElement?.dataset.code!)
+      copy(code)
+    }
+  })
+
+  const htmlString = () => {
+    if (props.showRawCode) return props.text
+
+    const raw = parseMarkdown(props.text)
+
+    // Replace the code block with a custom HTML structure that includes a copy button
+    const codeBlockRegex = /<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/g
+    const newHtml = raw.replace(codeBlockRegex, (match) => {
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(match, 'text/html')
+      const codeElement = doc.querySelector('code')
+      const code = codeElement ? codeElement.textContent : ''
+
+      return `<div relative>
+        <div data-code=${encodeURIComponent(code)} class="copy-btn code-copy-btn group">
+          ${
+            copied()
+              ? '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 32 32"><path fill="currentColor" d="m13 24l-9-9l1.414-1.414L13 21.171L26.586 7.586L28 9L13 24z"/></svg>'
+              : '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 32 32"><path fill="currentColor" d="M28 10v18H10V10h18m0-2H10a2 2 0 0 0-2 2v18a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2Z"/><path fill="currentColor" d="M4 18H2V4a2 2 0 0 1 2-2h14v2H4Z"/></svg>'
+          }
+          <div class="group-hover:op-90 code-copy-tips">
+            ${copied() ? 'Copied' : 'Copy'}
+          </div>
+        </div>
+        ${match}
+      </div>`
+    })
+
+    return newHtml
+  }
 
   return (
     <Show when={props.showRawCode} fallback={<div class={props.class ?? ''} innerHTML={htmlString()} />}>

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -78,6 +78,8 @@ export default defineConfig({
     'fi': 'flex items-center',
     'fcc': 'fc items-center',
     'fb': 'flex justify-between',
+    'code-copy-btn': 'absolute z-3 op-90 w-8 h-8 p-1 top-12px right-12px bg-light-300 dark:bg-dark-300 hover-text-emerald-600 fcc border rounded-md b-transparent cursor-pointer',
+    'code-copy-tips': 'absolute z-1 op-0 px-2 py-1 -top-8 bg-dark-600 dark:bg-dark fcc box-border rounded-md text-xs c-white transition-opacity duration-300 whitespace-nowrap',
   }],
   preflights: [{
     layer: 'base',


### PR DESCRIPTION
### Description

1. Refer to `chatgpt-demo/src/components/MessageItem.tsx`, add a copy button to the rendered code block in `src/components/Markdown.tsx`, and the icon uses `i-c Arbon-copy`, the emerald green will be displayed when the mouse is hovered, and it will become the `i-carbon-checkmark` icon after clicking.

2. The `code-copy-btn` and `code-copy-tips` styles have been added to `unocss.config.ts` for the code copy button.

3. `package.json` has added `solidjs-use` to implement the code copy function.

4. By the way, the setting switch of Vercel Analytics has been added to `astro.config.mjs`.

### Linked Issues

[#48](https://github.com/anse-app/anse/issues/48)

### Additional context

BUG: Initially, the mouse hover to display tips was set for the code copy button, but the hover will be triggered to display tips when the mouse covers the text interface, instead of the expected mouse cover to display when copying the button.

```tsx
const result = `<div relative>
  <div data-code=${encodeURIComponent(code)} data-index=${index} class="code-copy-btn group">
    ${copied()[index] === true ? '<i class="i-carbon-checkmark"></i>' : '<i class="i-carbon-copy"></i>'}
    <div class="group-hover:op-90 code-copy-tips">
      ${copied()[index] ? 'Copied' : 'Copy'}
    </div>
  </div>
  ${match}
</div>`
```

And the code that implements code copy is all placed in `Markdown.tsx`, which makes `Markdown.tsx` look less beautiful.

### Demo

[https://anse-tree.vercel.app](https://anse-tree.vercel.app)
<img width="1277" alt="截屏2023-09-13 17 05 54" src="https://github.com/anse-app/anse/assets/37926645/029e5fae-fc9c-4adb-8ad6-00bb04ac5f78">
