### PR TITLE
Feat/settings slider text input

### DIFF
--- a/src/components/ui/SettingsInput.tsx
+++ b/src/components/ui/SettingsInput.tsx
@@ -17,7 +17,7 @@ export default ({ settings, editing, value, setValue }: Props) => {
         <input
           type="text"
           value={value()}
-          class="w-full mt-1 bg-transparent border border-base px-2 py-1  focus:border-base-100 transition-colors-200"
+          class="w-full mt-1 bg-transparent border border-base px-2 py-1 focus:border-base-100 transition-colors-200"
           onChange={e => setValue(e.currentTarget.value)}
         />
       )}

--- a/src/components/ui/SettingsSlider.tsx
+++ b/src/components/ui/SettingsSlider.tsx
@@ -25,10 +25,10 @@ export default ({ settings, editing, value, setValue }: Props) => {
           step={sliderSettings.step}
         />
       )}
-      {!editing() && value() && (
+      {!editing() && value() !== undefined && (
         <div>{value()}</div>
       )}
-      {!editing() && !value() && (
+      {!editing() && value() === undefined && (
         <SettingsNotDefined />
       )}
     </div>

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -3,19 +3,6 @@ import { normalizeProps, useMachine } from '@zag-js/solid'
 import { createMemo, createSignal, createUniqueId, mergeProps } from 'solid-js'
 import type { Accessor } from 'solid-js'
 
-function adjustValueToStep(
-  value: number,
-  step: number,
-  min: number,
-  max: number,
-) {
-  const adjustedValue = Math.round((value - min) / step) * step + min
-  const boundedValue = Math.min(Math.max(adjustedValue, min), max)
-  const decimalPlaces = (step.toString().split('.')[1] || []).length
-
-  return parseFloat(boundedValue.toFixed(decimalPlaces))
-}
-
 interface Props {
   value: Accessor<number>
   min: number
@@ -84,7 +71,7 @@ export const Slider = (selectProps: Props) => {
             aria-valuenow={input()}
             aria-controls={api().hiddenInputProps.id}
             aria-live="off"
-            aria-label="Enter custom value to adjust slider"
+            aria-label="Enter value to adjust slider"
             data-scope="slider"
             class="bg-transparent border border-transparent w-[80px] text-right px-2 py-1 hover:border-base focus:border-base-100 transition-colors-200"
             value={input()}
@@ -131,4 +118,33 @@ export const Slider = (selectProps: Props) => {
       </div>
     </div>
   )
+}
+
+/**
+ * Adjusts the given value to the nearest multiple of 'step'
+ * and ensures that the result lies within the range [min, max].
+ *
+ * @param value - The value to be adjusted.
+ * @param step - The step size to which the value should be adjusted.
+ * @param min - The minimum allowable value.
+ * @param max - The maximum allowable value.
+ *
+ * @returns The adjusted value.
+ */
+function adjustValueToStep(
+  value: number,
+  step: number,
+  min: number,
+  max: number,
+) {
+  // Adjust the value to the nearest step
+  const adjustedValue = Math.round((value - min) / step) * step + min
+
+  // Clamp the value to the min and max
+  const boundedValue = Math.min(Math.max(adjustedValue, min), max)
+
+  // Round the value to the nearest decimal place
+  const decimalPlaces = (step.toString().split('.')[1] || []).length
+
+  return parseFloat(boundedValue.toFixed(decimalPlaces))
 }

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -22,18 +22,21 @@ interface Props {
   max: number
   step: number
   disabled?: boolean
-  isInputEditable?: boolean
+  canEditSliderViaInput?: boolean
   setValue: (v: number) => void
 }
 
 export const Slider = (selectProps: Props) => {
-  const props = mergeProps({
-    min: 0,
-    max: 10,
-    step: 1,
-    disabled: false,
-    isInputEditable: true,
-  }, selectProps)
+  const props = mergeProps(
+    {
+      min: 0,
+      max: 10,
+      step: 1,
+      disabled: false,
+      canEditSliderViaInput: true,
+    },
+    selectProps,
+  )
 
   const formatSliderValue = (value: number) => {
     if (!value) return 0
@@ -65,12 +68,12 @@ export const Slider = (selectProps: Props) => {
     <div {...api().rootProps}>
       <div class="text-xs op-50 focus-within:op-100 fb items-center">
         <div />
-        {!props.isInputEditable && (
+        {!props.canEditSliderViaInput && (
           <output {...api().outputProps}>
             {formatSliderValue(api().value)}
           </output>
         )}
-        {props.isInputEditable && (
+        {props.canEditSliderViaInput && (
           <input
             type="text"
             spellcheck={false}

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -86,7 +86,6 @@ export const Slider = (selectProps: Props) => {
             aria-live="off"
             aria-label="Enter custom value to adjust slider"
             data-scope="slider"
-            data-part="control"
             class="bg-transparent border border-transparent w-[80px] text-right px-2 py-1 hover:border-base focus:border-base-100 transition-colors-200"
             value={input()}
             onInput={(e) => {

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -84,7 +84,7 @@ export const Slider = (selectProps: Props) => {
             aria-label="Enter custom value to adjust slider"
             data-scope="slider"
             data-part="control"
-            class="bg-transparent border border-transparent w-[80px] text-right px-2 py-1 focus:border-base-100 transition-colors-200"
+            class="bg-transparent border border-transparent w-[80px] text-right px-2 py-1 hover:border-base focus:border-base-100 transition-colors-200"
             value={input()}
             onInput={(e) => {
               const target = e.target

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -1,7 +1,7 @@
 import * as slider from '@zag-js/slider'
 import { normalizeProps, useMachine } from '@zag-js/solid'
 import { createMemo, createSignal, createUniqueId, mergeProps } from 'solid-js'
-import type { Accessor } from 'solid-js'
+import type { Accessor, JSX } from 'solid-js'
 
 function adjustValueToStep(
   value: number,
@@ -9,8 +9,6 @@ function adjustValueToStep(
   min: number,
   max: number,
 ) {
-  if (!value) return 0
-
   // Ensure value is a multiple of step, starting from min.
   const adjustedValue = Math.round((value - min) / step) * step + min
 
@@ -29,6 +27,7 @@ interface Props {
   max: number
   step: number
   disabled?: boolean
+  isInputEditable?: boolean
   setValue: (v: number) => void
 }
 
@@ -38,6 +37,7 @@ export const Slider = (selectProps: Props) => {
     max: 10,
     step: 1,
     disabled: false,
+    isInputEditable: true,
   }, selectProps)
 
   const formatSliderValue = (value: number) => {
@@ -59,30 +59,32 @@ export const Slider = (selectProps: Props) => {
       if (!details) return
 
       const value = formatSliderValue(details.value)
-
-      if (details.value)
-        props.setValue(value)
-
+      props.setValue(value)
       setInput(value)
     },
   }))
 
   const api = createMemo(() => slider.connect(state, send, normalizeProps))
 
-  const onInput = (e: Event) => {
-    const target = e.target as HTMLInputElement
-    const value = target.value
+  const onInput: JSX.InputEventHandler<HTMLInputElement, InputEvent> = (
+    e,
+  ) => {
+    const target = e.target
+    let value = Number(target.value)
 
-    api().setValue(Number(value))
+    if (Number.isNaN(value)) value = props.value()
+
+    api().setValue(value)
   }
 
-  const onBlur = (e: Event) => {
-    const target = e.target as HTMLInputElement
+  const onBlur: JSX.FocusEventHandler<HTMLInputElement, FocusEvent> = (
+    event,
+  ) => {
+    const target = event.target
     let value = Number(target.value)
 
     // if input is not a number, reset to default value
-    if (Number.isNaN(value))
-      value = props.value()
+    if (Number.isNaN(value)) value = props.value()
 
     value = adjustValueToStep(value, props.step, props.min, props.max)
     setInput(value)
@@ -90,16 +92,25 @@ export const Slider = (selectProps: Props) => {
 
   return (
     <div {...api().rootProps}>
-      <div class="text-xs op-50 fb items-center">
+      <div class="text-xs op-50 focus-within:op-100 fb items-center">
         <div />
-        <output {...api().outputProps}>
-          <input
-            class="bg-transparent border border-base w-[80px] text-right px-2 py-1 focus:border-base-100 transition-colors-200"
-            onInput={onInput}
-            onBlur={onBlur}
-            value={input()}
-          />
-        </output>
+        {!props.isInputEditable && (
+          <output {...api().outputProps}>
+            {formatSliderValue(api().value)}
+          </output>
+        )}
+        {props.isInputEditable && (
+        <input
+          class="bg-transparent border border-transparent w-[80px] text-right px-2 py-1 focus:border-base-100 transition-colors-200"
+          onInput={onInput}
+          onBlur={onBlur}
+          value={input()}
+          onKeyUp={(e) => {
+            if (e.key === 'Enter')
+              e.currentTarget.blur()
+          }}
+        />
+        )}
       </div>
       <div class="mt-2" {...api().controlProps}>
         <div {...api().trackProps}>

--- a/src/components/ui/base/Slider.tsx
+++ b/src/components/ui/base/Slider.tsx
@@ -1,7 +1,27 @@
 import * as slider from '@zag-js/slider'
 import { normalizeProps, useMachine } from '@zag-js/solid'
-import { createMemo, createUniqueId, mergeProps } from 'solid-js'
+import { createMemo, createSignal, createUniqueId, mergeProps } from 'solid-js'
 import type { Accessor } from 'solid-js'
+
+function adjustValueToStep(
+  value: number,
+  step: number,
+  min: number,
+  max: number,
+) {
+  if (!value) return 0
+
+  // Ensure value is a multiple of step, starting from min.
+  const adjustedValue = Math.round((value - min) / step) * step + min
+
+  // Ensure the adjusted value is within the min and max range.
+  const boundedValue = Math.min(Math.max(adjustedValue, min), max)
+
+  // Limit the number of decimal places based on the step.
+  const decimalPlaces = (step.toString().split('.')[1] || []).length
+
+  return parseFloat(boundedValue.toFixed(decimalPlaces))
+}
 
 interface Props {
   value: Accessor<number>
@@ -22,8 +42,11 @@ export const Slider = (selectProps: Props) => {
 
   const formatSliderValue = (value: number) => {
     if (!value) return 0
+
     return Number.isInteger(value) ? value : parseFloat(value.toFixed(2))
   }
+
+  const [input, setInput] = createSignal(props.value(), { equals: false })
 
   const [state, send] = useMachine(slider.machine({
     id: createUniqueId(),
@@ -33,15 +56,50 @@ export const Slider = (selectProps: Props) => {
     step: props.step,
     disabled: props.disabled,
     onChange: (details) => {
-      details && details.value && props.setValue(formatSliderValue(details.value))
+      if (!details) return
+
+      const value = formatSliderValue(details.value)
+
+      if (details.value)
+        props.setValue(value)
+
+      setInput(value)
     },
   }))
+
   const api = createMemo(() => slider.connect(state, send, normalizeProps))
+
+  const onInput = (e: Event) => {
+    const target = e.target as HTMLInputElement
+    const value = target.value
+
+    api().setValue(Number(value))
+  }
+
+  const onBlur = (e: Event) => {
+    const target = e.target as HTMLInputElement
+    let value = Number(target.value)
+
+    // if input is not a number, reset to default value
+    if (Number.isNaN(value))
+      value = props.value()
+
+    value = adjustValueToStep(value, props.step, props.min, props.max)
+    setInput(value)
+  }
+
   return (
     <div {...api().rootProps}>
       <div class="text-xs op-50 fb items-center">
         <div />
-        <output {...api().outputProps}>{formatSliderValue(api().value)}</output>
+        <output {...api().outputProps}>
+          <input
+            class="bg-transparent border border-base w-[80px] text-right px-2 py-1 focus:border-base-100 transition-colors-200"
+            onInput={onInput}
+            onBlur={onBlur}
+            value={input()}
+          />
+        </output>
       </div>
       <div class="mt-2" {...api().controlProps}>
         <div {...api().trackProps}>


### PR DESCRIPTION
### Description

This PR simply improves the existing settings slider component by allowing users to directly input a slider's value. Previously, users would only interact with the slider via dragging the handle. Now, they have the option to either input the value manually through a text input or continue using the slider in the traditional manner. This improves user experience when interacting with the settings slider if precision is needed, or if the user prefers to input the intended value directly.

Before: 

https://github.com/anse-app/anse/assets/12883356/2ebd393a-3250-456b-a42c-74240760a53c

After:

https://github.com/anse-app/anse/assets/12883356/d2aaa535-fa62-4e20-b9e7-7c2c45f777e3


### Linked Issues

No linked issues.

### Additional context

1. A new utility function adjustValueToStep has been added to make sure the inputted values are within a valid range and adhere to the set step size.
2. The current default behaviour (i.e., not allowing manual input) is maintained if the prop `canEditSliderViaInput` is explicitly set to false. I've set it to true by default. 
