### PR TITLE
fix:Local DB conflicts with model and defaultSetting

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -12,6 +12,14 @@ export const rebuildSettingsStore = async() => {
   const defaultData = defaultSettingsStore()
   const data: Record<string, SettingsPayload> = {}
   providerMetaList.forEach((provider) => {
+    const modelSetting = getProviderById(provider.id)?.globalSettings?.find(obj => obj.key === 'model')
+    if (modelSetting?.type === 'select') {
+      const modelList = modelSetting.options
+      const isExistModel = modelList.some(model => model.value === exportData?.[provider.id]?.model)
+
+      if (!isExistModel && exportData?.[provider.id]?.model)
+        exportData[provider.id].model = modelList?.[0]?.value
+    }
     data[provider.id] = {
       ...defaultData[provider.id] || {},
       ...exportData?.[provider.id] || {},


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

If the model saved in the local DB does not exist in the default setting, it will be automatically updated to the first model in the model list options in the default setting.

### Linked Issues


### Additional context

For example, if I originally provided GPT4 services, but later only want to provide GPT3.5, the default database settings will cause the optional model list in the updated settings to be invalid. As long as the user does not manually adjust the selected model, the GPT4 model will always be used.