### PR TITLE
fix: Chinese characters decoder bug

### DIFF
--- a/src/logics/stream.ts
+++ b/src/logics/stream.ts
@@ -9,7 +9,7 @@ export const convertReadableStreamToAccessor = async(stream: ReadableStream, set
     while (!done) {
       const { value, done: readerDone } = await reader.read()
       if (value) {
-        const char = decoder.decode(value)
+        const char = decoder.decode(value, { stream: true })
         if (char) {
           text += char
           setter(text)

--- a/src/providers/azure/parser.ts
+++ b/src/providers/azure/parser.ts
@@ -35,7 +35,7 @@ export const parseStream = (rawResponse: Response) => {
           controller.close()
           return
         }
-        parser.feed(decoder.decode(value))
+        parser.feed(decoder.decode(value, { stream: true }))
       }
     },
   })

--- a/src/providers/google/parser.ts
+++ b/src/providers/google/parser.ts
@@ -66,7 +66,7 @@ export const parseStream = (rawResponse: Response) => {
           controller.close()
           return
         }
-        parser.feed(decoder.decode(value))
+        parser.feed(decoder.decode(value, { stream: true }))
       }
     },
   })

--- a/src/providers/openai/parser.ts
+++ b/src/providers/openai/parser.ts
@@ -35,7 +35,7 @@ export const parseStream = (rawResponse: Response) => {
           controller.close()
           return
         }
-        parser.feed(decoder.decode(value))
+        parser.feed(decoder.decode(value, { stream: true }))
       }
     },
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

A Chinese character is typically represented by multiple bytes. During decoding, incomplete byte sequences may be encountered, resulting in garbled characters. 


### Linked Issues

https://github.com/anse-app/anse/issues/126

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This link might help:

https://github.com/whatwg/encoding/issues/184

In theory, it might also work to cache and concatenate in advance to prevent garbled characters. However, I have found that this can only reduce but not eliminate the occurrence of garbled characters. Using a decoder for streaming transmission is a better choice.
